### PR TITLE
perf(cache): delay expiration cleanup on startup

### DIFF
--- a/Sources/clai/Cache/ResponseCache.swift
+++ b/Sources/clai/Cache/ResponseCache.swift
@@ -24,6 +24,8 @@ final class ResponseCache: @unchecked Sendable {
         // Optimize startup: Run cleanup in background
         // This avoids blocking ClaiEngine initialization on DB operations
         Task { [weak self] in
+            // Delay cleanup to ensure it doesn't contend with the first request
+            try? await Task.sleep(for: .seconds(2))
             try? self?.cleanupExpired()
         }
     }


### PR DESCRIPTION
Delays background cache cleanup by 2 seconds to prevent database lock contention during the critical startup path of the first command execution.

Found that `ResponseCache.init` spawns a background task `cleanupExpired` which initializes the database connection and performs a delete query. This task runs concurrently with `ClaiEngine`'s handling of the first user request, which also tries to initialize the database connection (via `cache.get`). Since `ResponseCache` uses a lock to serialize access, this creates contention. Delaying the cleanup task allows the user request to win the race and initialize the DB first, improving perceived startup latency.

---
*PR created automatically by Jules for task [7771185692152561568](https://jules.google.com/task/7771185692152561568) started by @alexey1312*