### PR TITLE
style(ui): improve spinner feedback with success/failure states

### DIFF
--- a/Sources/clai/UI/Spinner.swift
+++ b/Sources/clai/UI/Spinner.swift
@@ -31,8 +31,9 @@ final class Spinner: Sendable {
         }
     }
 
-    func stop() {
+    func stop() async {
         task.cancel()
+        _ = await task.result
     }
 }
 

--- a/Sources/clai/UI/TerminalUI.swift
+++ b/Sources/clai/UI/TerminalUI.swift
@@ -51,8 +51,19 @@ final class TerminalUI: @unchecked Sendable {
         }
 
         let spinner = Spinner(message: message)
-        defer { spinner.stop() }
-        return try await operation()
+
+        do {
+            let result = try await operation()
+            await spinner.stop()
+            print("\r\(Theme.success)✔\(Theme.reset) \(message)")
+            flushStdout()
+            return result
+        } catch {
+            await spinner.stop()
+            print("\r\(Theme.error)✖\(Theme.reset) \(message)")
+            flushStdout()
+            throw error
+        }
     }
 
     func showProgress(_ message: String) {


### PR DESCRIPTION
Improved the spinner UX by making it persistent. Instead of disappearing, the spinner is replaced by a checkmark or cross indicating the operation's result. This provides better feedback to the user about what just happened.

Changes:
- Modified `Sources/clai/UI/Spinner.swift` to make `stop()` async.
- Modified `Sources/clai/UI/TerminalUI.swift` to use `do-catch` instead of `defer` for spinner management, ensuring the final status is printed after the spinner stops.


---
*PR created automatically by Jules for task [10405108413004588495](https://jules.google.com/task/10405108413004588495) started by @alexey1312*