### PR TITLE
perf(context): optimize tldr check in ContextGatherer

### DIFF
--- a/Sources/clai/Core/ContextGatherer.swift
+++ b/Sources/clai/Core/ContextGatherer.swift
@@ -11,24 +11,8 @@ struct CommandContext: Sendable {
     }
 }
 
-/// Actor for caching tldr availability
-private actor TldrAvailabilityCache {
-    private var isTldrInstalled: Bool?
-
-    func get() -> Bool? {
-        isTldrInstalled
-    }
-
-    func set(_ value: Bool) {
-        isTldrInstalled = value
-    }
-}
-
 /// Gathers context about commands from help, man pages, and tldr
 final class ContextGatherer: Sendable {
-    /// Cached availability of tldr (actor-based for async safety)
-    private static let tldrCache = TldrAvailabilityCache()
-
     /// Gather all available context for a command
     func gather(for command: String) async throws -> CommandContext {
         async let helpOutput = getHelpOutput(for: command)
@@ -63,30 +47,7 @@ final class ContextGatherer: Sendable {
     /// Get tldr page if available
     func getTldrPage(for command: String) async throws -> String? {
         let baseCommand = command.split(separator: " ").first.map(String.init) ?? command
-
-        if await !Self.checkTldrAvailability() {
-            return nil
-        }
-
         return try await runCommand("tldr \(baseCommand)")
-    }
-
-    /// Check if tldr is installed, caching the result
-    private static func checkTldrAvailability() async -> Bool {
-        // Check cache first (actor-based for async safety)
-        if let installed = await tldrCache.get() {
-            return installed
-        }
-
-        // Not cached, check system
-        // Note: We instantiate a temporary gatherer just to run the command
-        // to avoid making runCommand static or exposing it
-        let installed = await (try? ContextGatherer().runCommand("which tldr")) != nil
-
-        // Update cache
-        await tldrCache.set(installed)
-
-        return installed
     }
 
     private func runCommand(_ command: String) async throws -> String {


### PR DESCRIPTION
Optimized `ContextGatherer` by removing the redundant `which tldr` check. This eliminates an unnecessary subprocess spawn and filesystem lookup for every `explain` or `examples` command execution, streamlining the context gathering process. The `tldr` command is now executed directly, and any failures (including if `tldr` is not installed) are handled gracefully by the existing error handling logic in `gather(for:)`. This improves startup latency and reduces resource usage.

---
*PR created automatically by Jules for task [3755971551068407955](https://jules.google.com/task/3755971551068407955) started by @alexey1312*