### PR TITLE
perf(startup): optimize Config.load() with in-memory caching

### DIFF
--- a/Sources/clai/Config/ConfigLoading.swift
+++ b/Sources/clai/Config/ConfigLoading.swift
@@ -12,16 +12,29 @@ extension Config {
         return configDir.appendingPathComponent("config.yaml")
     }
 
+    /// Cached configuration to avoid redundant I/O
+    private nonisolated(unsafe) static var _cachedConfig: Config?
+    private static let loadLock = NSLock()
+
     /// Load configuration from file (single source of truth)
     ///
     /// Flow:
-    /// 1. Create config file with defaults if it doesn't exist
-    /// 2. Load from file (the only source)
-    /// 3. Apply environment variable overrides
-    /// 4. Validate
+    /// 1. Check in-memory cache
+    /// 2. Create config file with defaults if it doesn't exist
+    /// 3. Load from file (the only source)
+    /// 4. Apply environment variable overrides
+    /// 5. Validate
+    /// 6. Cache and return
     ///
     /// - Throws: `ConfigError` on file/parsing errors, `ValidationError` on invalid values
     static func load() throws -> Config {
+        loadLock.lock()
+        defer { loadLock.unlock() }
+
+        if let cached = _cachedConfig {
+            return cached
+        }
+
         let fileURL = configFileURL
 
         // 1. Create file with defaults if it doesn't exist
@@ -38,6 +51,7 @@ extension Config {
         // 4. Validate
         try config.validate()
 
+        _cachedConfig = config
         return config
     }
 
@@ -271,5 +285,10 @@ extension Config {
         } catch {
             throw ConfigError.fileCreationFailed(path: fileURL.path, underlying: error)
         }
+
+        // Update cache
+        Config.loadLock.lock()
+        Config._cachedConfig = self
+        Config.loadLock.unlock()
     }
 }


### PR DESCRIPTION
Implemented an in-memory cache for `Config.load()` to prevent redundant file I/O and YAML parsing. The configuration is loaded from disk once and stored in a thread-safe static variable. Subsequent calls to `load()` return the cached configuration. The cache is updated whenever `save()` is called to ensure consistency.

This optimization is particularly beneficial for the CLI startup time, as `Config.load()` is called multiple times during the initialization of different components (e.g., `ClaiEngine` and `ProviderManager` via `MLXProvider.createIfAvailable`).

Verified the changes by code review and a small test script to confirm static stored properties in extensions are valid in this Swift version. Full test suite execution failed due to environment instability (Signal 11 in swift-syntax compilation).

---
*PR created automatically by Jules for task [1777811368964056199](https://jules.google.com/task/1777811368964056199) started by @alexey1312*