### PR TITLE
perf(startup): cache Config.load to reduce I/O

### DIFF
--- a/Sources/clai/Config/ConfigLoading.swift
+++ b/Sources/clai/Config/ConfigLoading.swift
@@ -4,6 +4,10 @@ import Yams
 // MARK: - Config Loading
 
 extension Config {
+    /// Cached configuration to avoid redundant disk I/O
+    private nonisolated(unsafe) static var _cachedConfig: Config?
+    private static let loadLock = NSLock()
+
     /// Config file location
     static var configFileURL: URL {
         let configDir = FileManager.default.homeDirectoryForCurrentUser
@@ -22,6 +26,13 @@ extension Config {
     ///
     /// - Throws: `ConfigError` on file/parsing errors, `ValidationError` on invalid values
     static func load() throws -> Config {
+        loadLock.lock()
+        defer { loadLock.unlock() }
+
+        if let cached = _cachedConfig {
+            return cached
+        }
+
         let fileURL = configFileURL
 
         // 1. Create file with defaults if it doesn't exist
@@ -38,6 +49,7 @@ extension Config {
         // 4. Validate
         try config.validate()
 
+        _cachedConfig = config
         return config
     }
 
@@ -271,5 +283,10 @@ extension Config {
         } catch {
             throw ConfigError.fileCreationFailed(path: fileURL.path, underlying: error)
         }
+
+        // Update cache with the saved configuration
+        Config.loadLock.lock()
+        Config._cachedConfig = self
+        Config.loadLock.unlock()
     }
 }

--- a/Tests/claiTests/CachePerfTests.swift
+++ b/Tests/claiTests/CachePerfTests.swift
@@ -1,6 +1,6 @@
 @testable import clai
-import XCTest
 import Crypto
+import XCTest
 
 final class CachePerfTests: XCTestCase {
     // Helper to generate a unique cache key
@@ -22,7 +22,7 @@ final class CachePerfTests: XCTestCase {
         let start = Date()
 
         await withTaskGroup(of: Void.self) { group in
-            for i in 0..<concurrentOps {
+            for i in 0 ..< concurrentOps {
                 group.addTask {
                     let key = CachePerfTests.uniqueKey(i)
                     let response = "Response for \(i)"
@@ -46,7 +46,7 @@ final class CachePerfTests: XCTestCase {
         let readStart = Date()
 
         await withTaskGroup(of: Void.self) { group in
-            for i in 0..<concurrentOps {
+            for i in 0 ..< concurrentOps {
                 group.addTask {
                     let key = CachePerfTests.uniqueKey(i)
                     do {

--- a/Tests/claiTests/PerformanceTests.swift
+++ b/Tests/claiTests/PerformanceTests.swift
@@ -24,7 +24,7 @@ final class PerformanceTests: XCTestCase {
 
         // Measure time block
         measure {
-            for _ in 0..<iterations {
+            for _ in 0 ..< iterations {
                 _ = ByteFormatter.format(bytes)
             }
         }

--- a/Tests/claiTests/ResponseCacheTests.swift
+++ b/Tests/claiTests/ResponseCacheTests.swift
@@ -1,6 +1,6 @@
 @testable import clai
-import XCTest
 import Crypto
+import XCTest
 
 final class ResponseCacheTests: XCTestCase {
     // Helper to generate a unique cache key
@@ -45,7 +45,10 @@ final class ResponseCacheTests: XCTestCase {
         let response = "Expired Response"
 
         // Exactly 7 days + 1 second ago
-        guard let oldDate = Calendar.current.date(byAdding: .second, value: -1, to:
+        guard let oldDate = Calendar.current.date(
+            byAdding: .second,
+            value: -1,
+            to:
             Calendar.current.date(byAdding: .day, value: -7, to: Date())!
         ) else {
             XCTFail("Could not calculate old date")
@@ -64,7 +67,10 @@ final class ResponseCacheTests: XCTestCase {
         let response = "Valid Response"
 
         // Exactly 7 days - 1 hour ago
-        guard let oldDate = Calendar.current.date(byAdding: .hour, value: 1, to:
+        guard let oldDate = Calendar.current.date(
+            byAdding: .hour,
+            value: 1,
+            to:
             Calendar.current.date(byAdding: .day, value: -7, to: Date())!
         ) else {
             XCTFail("Could not calculate old date")


### PR DESCRIPTION
This PR introduces caching for `Config.load()` to optimize startup time. 

`Config.load()` is called multiple times during the application lifecycle (e.g., in `ClaiEngine` initialization and subsequently in `MLXProvider` initialization via `ProviderManager`). Previously, each call would read the configuration file from disk and parse the YAML content.

The changes include:
1.  Adding a `private nonisolated(unsafe) static var _cachedConfig: Config?` to the `Config` struct to store the loaded configuration.
2.  Protecting access to the cache with `private static let loadLock = NSLock()`.
3.  Modifying `Config.load()` to return the cached configuration if available.
4.  Updating `Config.save()` to refresh the cache with the new configuration upon a successful save.

This optimization reduces I/O overhead and avoids unnecessary object allocation during startup, contributing to a snappier CLI experience.


---
*PR created automatically by Jules for task [7090933954897540062](https://jules.google.com/task/7090933954897540062) started by @alexey1312*