### PR TITLE
perf(providers): optimize Ollama availability check to pre-fetch models

### DIFF
--- a/Sources/clai/Providers/OllamaChecker.swift
+++ b/Sources/clai/Providers/OllamaChecker.swift
@@ -61,6 +61,19 @@ enum OllamaChecker {
             return result
         }
 
+        // Try to fetch models as a robust availability check
+        // This also pre-warms the model cache, avoiding a second request during instantiation
+        if let models = try? await fetchModelsDetailed(host: host) {
+            _cacheLock.withLock {
+                _cachedAvailability = AvailabilityCache(
+                    host: host, timestamp: Date(), isAvailable: true, models: models
+                )
+            }
+            return true
+        }
+
+        // Fallback: Basic check against root if /api/tags fails
+        // This handles cases where API might be restricted or behaves differently
         let isAvailable = await {
             guard let url = URL(string: "\(host)/") else {
                 return false
@@ -117,23 +130,8 @@ enum OllamaChecker {
             return models
         }
 
-        guard let url = URL(string: "\(host)/api/tags") else {
-            return []
-        }
-
         do {
-            let (data, _) = try await checkSession.data(from: url)
-            let response = try JSONDecoder().decode(OllamaTagsResponse.self, from: data)
-
-            let detailedModels: [OllamaModelInfo] = response.models.map { model in
-                let sizeBytes = Int64(model.size ?? 0)
-                return OllamaModelInfo(
-                    name: model.name,
-                    sizeBytes: sizeBytes,
-                    sizeFormatted: ByteFormatter.format(sizeBytes),
-                    digest: model.digest ?? ""
-                )
-            }
+            let detailedModels = try await fetchModelsDetailed(host: host)
 
             // Update cache with fresh models
             _cacheLock.withLock {
@@ -148,6 +146,31 @@ enum OllamaChecker {
                 fputs("OllamaChecker.availableModelsDetailed: \(error.localizedDescription)\n", stderr)
             #endif
             return []
+        }
+    }
+
+    /// Private helper to fetch models from API
+    private static func fetchModelsDetailed(host: String) async throws -> [OllamaModelInfo] {
+        guard let url = URL(string: "\(host)/api/tags") else {
+            throw OllamaError.invalidURL
+        }
+
+        let (data, response) = try await checkSession.data(from: url)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw OllamaError.pullFailed("Status code not 200")
+        }
+
+        let decodedResponse = try JSONDecoder().decode(OllamaTagsResponse.self, from: data)
+
+        return decodedResponse.models.map { model in
+            let sizeBytes = Int64(model.size ?? 0)
+            return OllamaModelInfo(
+                name: model.name,
+                sizeBytes: sizeBytes,
+                sizeFormatted: ByteFormatter.format(sizeBytes),
+                digest: model.digest ?? ""
+            )
         }
     }
 


### PR DESCRIPTION
Optimize Ollama provider initialization by combining availability check with model list fetching.

### Motivation
Currently, `OllamaChecker.isAvailable` (called in parallel during startup) only checks if the service is reachable. Later, when the provider is instantiated (sequentially), it calls `availableModelsDetailed` which triggers a second network request. This adds latency to the critical path.

### Changes
- Refactored `OllamaChecker` to use a private `fetchModelsDetailed` helper.
- Updated `isAvailable` to attempt fetching models. If successful, it populates the cache immediately.
- If model fetching fails (e.g. API error), it falls back to the original connectivity check.

### Verification
- Logic manually verified to ensure correct cache population and fallback behavior.
- Linted with `swiftlint` (via `mise exec`).
- Attempted local build/test but environment issues (Signal 11 in `swift-frontend`) prevented execution. Code changes are confined to logic flow and standard library usage.

---
*PR created automatically by Jules for task [15182532135048280381](https://jules.google.com/task/15182532135048280381) started by @alexey1312*