### PR TITLE
perf(providers): reduce Ollama availability check timeout

### DIFF
--- a/Sources/clai/Providers/OllamaChecker.swift
+++ b/Sources/clai/Providers/OllamaChecker.swift
@@ -39,8 +39,8 @@ enum OllamaChecker {
     // Dedicated session with short timeout for availability checks
     private static let checkSession: URLSession = {
         let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 2.0 // Fail fast if unresponsive
-        config.timeoutIntervalForResource = 5.0
+        config.timeoutIntervalForRequest = 0.5 // Fail fast if unresponsive
+        config.timeoutIntervalForResource = 1.0
         return URLSession(configuration: config)
     }()
 


### PR DESCRIPTION
Reduced the timeout for Ollama availability checks to fail fast when the service is unreachable. This prevents a 2-second delay for users who have Ollama in their provider chain (default) but do not have the service running, allowing the tool to fallback to other providers (like Anthropic or OpenAI) much faster.

---
*PR created automatically by Jules for task [2927701744657097839](https://jules.google.com/task/2927701744657097839) started by @alexey1312*