### PR TITLE
perf(config): cache parsed configuration to avoid redundant disk I/O and parsing

### DIFF
--- a/Sources/clai/Config/ConfigLoading.swift
+++ b/Sources/clai/Config/ConfigLoading.swift
@@ -4,6 +4,10 @@ import Yams
 // MARK: - Config Loading
 
 extension Config {
+    // Thread-safe cache for the parsed configuration
+    private nonisolated(unsafe) static var _cachedConfig: Config?
+    private static let lock = NSLock()
+
     /// Config file location
     static var configFileURL: URL {
         let configDir = FileManager.default.homeDirectoryForCurrentUser
@@ -22,6 +26,13 @@ extension Config {
     ///
     /// - Throws: `ConfigError` on file/parsing errors, `ValidationError` on invalid values
     static func load() throws -> Config {
+        lock.lock()
+        if let cached = _cachedConfig {
+            lock.unlock()
+            return cached
+        }
+        lock.unlock()
+
         let fileURL = configFileURL
 
         // 1. Create file with defaults if it doesn't exist
@@ -37,6 +48,10 @@ extension Config {
 
         // 4. Validate
         try config.validate()
+
+        lock.lock()
+        _cachedConfig = config
+        lock.unlock()
 
         return config
     }
@@ -268,6 +283,9 @@ extension Config {
 
         do {
             try yamlString.write(to: fileURL, atomically: true, encoding: .utf8)
+            Config.lock.lock()
+            Config._cachedConfig = self
+            Config.lock.unlock()
         } catch {
             throw ConfigError.fileCreationFailed(path: fileURL.path, underlying: error)
         }


### PR DESCRIPTION
This PR introduces an in-memory cache for the parsed application configuration to improve performance.

**Problem:**
`Config.load()` is invoked in several places (`ClaiEngine`, `ModelsManager`, `ProviderManager`, `DaemonServer`), and each call involves synchronous disk I/O, YAML parsing via Yams, applying environment overrides, and schema validation. This causes unnecessary overhead, particularly during initialization and operation routing.

**Solution:**
- Added a `private nonisolated(unsafe) static var _cachedConfig: Config?` and an `NSLock` to `Config` to safely store the parsed configuration in memory.
- Updated `Config.load()` to return the cached config if available, bypassing all the file and parsing logic.
- Updated `Config.save()` to write the file atomically and immediately update the static cache so that changes are instantly reflected without requiring a reload from disk.

This directly addresses the "Cache Optimization" and "Startup Time" performance goals by ensuring that configuration is parsed from the filesystem exactly once per application run (unless explicitly saved).

---
*PR created automatically by Jules for task [5630528514978372528](https://jules.google.com/task/5630528514978372528) started by @alexey1312*