### PR TITLE
perf(config): cache parsed configuration to avoid redundant disk I/O

### DIFF
--- a/Sources/clai/Config/ConfigLoading.swift
+++ b/Sources/clai/Config/ConfigLoading.swift
@@ -4,6 +4,9 @@ import Yams
 // MARK: - Config Loading
 
 extension Config {
+    private nonisolated(unsafe) static var _cachedConfig: Config?
+    private static let _cacheLock = NSLock()
+
     /// Config file location
     static var configFileURL: URL {
         let configDir = FileManager.default.homeDirectoryForCurrentUser
@@ -22,6 +25,15 @@ extension Config {
     ///
     /// - Throws: `ConfigError` on file/parsing errors, `ValidationError` on invalid values
     static func load() throws -> Config {
+        _cacheLock.lock()
+        if let cached = _cachedConfig {
+            _cacheLock.unlock()
+            var config = cached.applyingEnvironmentOverrides()
+            try config.validate()
+            return config
+        }
+        _cacheLock.unlock()
+
         let fileURL = configFileURL
 
         // 1. Create file with defaults if it doesn't exist
@@ -30,10 +42,14 @@ extension Config {
         }
 
         // 2. Load from file (single source of truth)
-        var config = try loadFromFile(at: fileURL)
+        let loadedConfig = try loadFromFile(at: fileURL)
+
+        _cacheLock.lock()
+        _cachedConfig = loadedConfig
+        _cacheLock.unlock()
 
         // 3. Apply environment variable overrides
-        config = config.applyingEnvironmentOverrides()
+        var config = loadedConfig.applyingEnvironmentOverrides()
 
         // 4. Validate
         try config.validate()
@@ -271,5 +287,19 @@ extension Config {
         } catch {
             throw ConfigError.fileCreationFailed(path: fileURL.path, underlying: error)
         }
+
+        Config._cacheLock.lock()
+        // The simplest and safest approach is to clear the cache upon saving,
+        // so the next `load()` will read the newly written configuration from
+        // disk, establishing a fresh baseline before environment overrides.
+        Config._cachedConfig = nil
+        Config._cacheLock.unlock()
+    }
+
+    /// Clear the configuration cache (useful for testing)
+    static func clearCache() {
+        _cacheLock.lock()
+        _cachedConfig = nil
+        _cacheLock.unlock()
     }
 }

--- a/Tests/claiTests/CachePerfTests.swift
+++ b/Tests/claiTests/CachePerfTests.swift
@@ -1,6 +1,6 @@
 @testable import clai
-import XCTest
 import Crypto
+import XCTest
 
 final class CachePerfTests: XCTestCase {
     // Helper to generate a unique cache key
@@ -22,7 +22,7 @@ final class CachePerfTests: XCTestCase {
         let start = Date()
 
         await withTaskGroup(of: Void.self) { group in
-            for i in 0..<concurrentOps {
+            for i in 0 ..< concurrentOps {
                 group.addTask {
                     let key = CachePerfTests.uniqueKey(i)
                     let response = "Response for \(i)"
@@ -46,7 +46,7 @@ final class CachePerfTests: XCTestCase {
         let readStart = Date()
 
         await withTaskGroup(of: Void.self) { group in
-            for i in 0..<concurrentOps {
+            for i in 0 ..< concurrentOps {
                 group.addTask {
                     let key = CachePerfTests.uniqueKey(i)
                     do {

--- a/Tests/claiTests/ConfigTests.swift
+++ b/Tests/claiTests/ConfigTests.swift
@@ -6,6 +6,10 @@ import Yams
 
 @Suite("Configuration Tests")
 struct ConfigurationTests {
+    init() {
+        Config.clearCache()
+    }
+
     @Test("Config has valid defaults")
     func defaultConfig() {
         let config = Config.default

--- a/Tests/claiTests/PerformanceTests.swift
+++ b/Tests/claiTests/PerformanceTests.swift
@@ -24,7 +24,7 @@ final class PerformanceTests: XCTestCase {
 
         // Measure time block
         measure {
-            for _ in 0..<iterations {
+            for _ in 0 ..< iterations {
                 _ = ByteFormatter.format(bytes)
             }
         }

--- a/Tests/claiTests/ResponseCacheTests.swift
+++ b/Tests/claiTests/ResponseCacheTests.swift
@@ -1,6 +1,6 @@
 @testable import clai
-import XCTest
 import Crypto
+import XCTest
 
 final class ResponseCacheTests: XCTestCase {
     // Helper to generate a unique cache key
@@ -45,7 +45,10 @@ final class ResponseCacheTests: XCTestCase {
         let response = "Expired Response"
 
         // Exactly 7 days + 1 second ago
-        guard let oldDate = Calendar.current.date(byAdding: .second, value: -1, to:
+        guard let oldDate = Calendar.current.date(
+            byAdding: .second,
+            value: -1,
+            to:
             Calendar.current.date(byAdding: .day, value: -7, to: Date())!
         ) else {
             XCTFail("Could not calculate old date")
@@ -64,7 +67,10 @@ final class ResponseCacheTests: XCTestCase {
         let response = "Valid Response"
 
         // Exactly 7 days - 1 hour ago
-        guard let oldDate = Calendar.current.date(byAdding: .hour, value: 1, to:
+        guard let oldDate = Calendar.current.date(
+            byAdding: .hour,
+            value: 1,
+            to:
             Calendar.current.date(byAdding: .day, value: -7, to: Date())!
         ) else {
             XCTFail("Could not calculate old date")


### PR DESCRIPTION
This PR implements an in-memory cache for the loaded configuration in `ConfigLoading.swift` to optimize performance. Previously, calling `Config.load()` would perform disk I/O to read the `config.yaml` file and parse it via `Yams` on every invocation.

By introducing `private nonisolated(unsafe) static var _cachedConfig` and protecting it with `NSLock`, we ensure thread-safe retrieval of the configuration. Environment variable overrides are dynamically applied post-cache retrieval. When `Config.save()` is executed, the cache is proactively cleared so subsequent `load()` calls reflect the new disk baseline.

Test suites have been updated to `Config.clearCache()` on `init()` to avoid test pollution across units.

---
*PR created automatically by Jules for task [13109064176018965797](https://jules.google.com/task/13109064176018965797) started by @alexey1312*