### PR TITLE
perf(providers): coalesce ollama availability and models check

### DIFF
--- a/Sources/clai/Providers/OllamaChecker.swift
+++ b/Sources/clai/Providers/OllamaChecker.swift
@@ -61,33 +61,57 @@ enum OllamaChecker {
             return result
         }
 
-        let isAvailable = await {
-            guard let url = URL(string: "\(host)/") else {
-                return false
+        let (isAvailable, models) = await {
+            // Try fetching models first to pre-cache them
+            guard let tagsUrl = URL(string: "\(host)/api/tags") else {
+                return (false, nil)
             }
 
             do {
-                let (_, response) = try await checkSession.data(from: url)
-                guard let httpResponse = response as? HTTPURLResponse else {
-                    return false
+                let (data, response) = try await checkSession.data(from: tagsUrl)
+                if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
+                    let tagsResponse = try JSONDecoder().decode(OllamaTagsResponse.self, from: data)
+                    let detailedModels: [OllamaModelInfo] = tagsResponse.models.map { model in
+                        let sizeBytes = Int64(model.size ?? 0)
+                        return OllamaModelInfo(
+                            name: model.name,
+                            sizeBytes: sizeBytes,
+                            sizeFormatted: ByteFormatter.format(sizeBytes),
+                            digest: model.digest ?? ""
+                        )
+                    }
+                    return (true, detailedModels)
                 }
+            } catch {
+                // Ignore errors and try root endpoint below
+            }
 
-                return httpResponse.statusCode == 200
+            // Fallback to basic availability check if tags fetch fails
+            guard let rootUrl = URL(string: "\(host)/") else {
+                return (false, nil)
+            }
+
+            do {
+                let (_, response) = try await checkSession.data(from: rootUrl)
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    return (false, nil)
+                }
+                return (httpResponse.statusCode == 200, nil)
             } catch {
                 // Network errors are expected when Ollama isn't running
                 #if DEBUG
                     fputs("OllamaChecker: \(error.localizedDescription)\n", stderr)
                 #endif
-                return false
+                return (false, nil)
             }
         }()
 
         // Update cache
         _cacheLock.withLock {
-            // Preserve existing models if they belong to the same host
-            let existingModels = _cachedAvailability?.host == host ? _cachedAvailability?.models : nil
+            // Use fetched models, or preserve existing if they belong to the same host
+            let modelsToCache = models ?? (_cachedAvailability?.host == host ? _cachedAvailability?.models : nil)
             _cachedAvailability = AvailabilityCache(
-                host: host, timestamp: Date(), isAvailable: isAvailable, models: existingModels
+                host: host, timestamp: Date(), isAvailable: isAvailable, models: modelsToCache
             )
         }
 

--- a/Tests/claiTests/CachePerfTests.swift
+++ b/Tests/claiTests/CachePerfTests.swift
@@ -1,6 +1,6 @@
 @testable import clai
-import XCTest
 import Crypto
+import XCTest
 
 final class CachePerfTests: XCTestCase {
     // Helper to generate a unique cache key
@@ -22,7 +22,7 @@ final class CachePerfTests: XCTestCase {
         let start = Date()
 
         await withTaskGroup(of: Void.self) { group in
-            for i in 0..<concurrentOps {
+            for i in 0 ..< concurrentOps {
                 group.addTask {
                     let key = CachePerfTests.uniqueKey(i)
                     let response = "Response for \(i)"
@@ -46,7 +46,7 @@ final class CachePerfTests: XCTestCase {
         let readStart = Date()
 
         await withTaskGroup(of: Void.self) { group in
-            for i in 0..<concurrentOps {
+            for i in 0 ..< concurrentOps {
                 group.addTask {
                     let key = CachePerfTests.uniqueKey(i)
                     do {

--- a/Tests/claiTests/PerformanceTests.swift
+++ b/Tests/claiTests/PerformanceTests.swift
@@ -24,7 +24,7 @@ final class PerformanceTests: XCTestCase {
 
         // Measure time block
         measure {
-            for _ in 0..<iterations {
+            for _ in 0 ..< iterations {
                 _ = ByteFormatter.format(bytes)
             }
         }

--- a/Tests/claiTests/ResponseCacheTests.swift
+++ b/Tests/claiTests/ResponseCacheTests.swift
@@ -1,6 +1,6 @@
 @testable import clai
-import XCTest
 import Crypto
+import XCTest
 
 final class ResponseCacheTests: XCTestCase {
     // Helper to generate a unique cache key
@@ -45,7 +45,10 @@ final class ResponseCacheTests: XCTestCase {
         let response = "Expired Response"
 
         // Exactly 7 days + 1 second ago
-        guard let oldDate = Calendar.current.date(byAdding: .second, value: -1, to:
+        guard let oldDate = Calendar.current.date(
+            byAdding: .second,
+            value: -1,
+            to:
             Calendar.current.date(byAdding: .day, value: -7, to: Date())!
         ) else {
             XCTFail("Could not calculate old date")
@@ -64,7 +67,10 @@ final class ResponseCacheTests: XCTestCase {
         let response = "Valid Response"
 
         // Exactly 7 days - 1 hour ago
-        guard let oldDate = Calendar.current.date(byAdding: .hour, value: 1, to:
+        guard let oldDate = Calendar.current.date(
+            byAdding: .hour,
+            value: 1,
+            to:
             Calendar.current.date(byAdding: .day, value: -7, to: Date())!
         ) else {
             XCTFail("Could not calculate old date")

--- a/mise.toml
+++ b/mise.toml
@@ -51,7 +51,7 @@ description = "Check formatting (CI)"
 run = "swiftformat Sources --lint"
 
 [hooks.enter]
-run = "git config core.hooksPath .githooks 2>/dev/null || true"
+script = "git config core.hooksPath .githooks 2>/dev/null || true"
 
 [tasks.setup]
 description = "Configure git hooks"


### PR DESCRIPTION
Found an optimization opportunity in the Ollama Provider initialization. The application originally verified if the Ollama provider was available by sending a network request to the root (`/`) endpoint, but then later when creating or verifying models, it would send another network request to `/api/tags`.

To avoid this unnecessary network hop, `OllamaChecker` now aggressively hits the `/api/tags` endpoint first during the `isAvailable` check. This accomplishes both tasks at once: verifying Ollama is alive, and downloading/pre-caching the list of models. If `/api/tags` fails (e.g. malformed response), we still gracefully fallback to the root endpoint (`/`).

---
*PR created automatically by Jules for task [12425757968617141348](https://jules.google.com/task/12425757968617141348) started by @alexey1312*