### PR TITLE
perf(config): Cache parsed config in memory to avoid redundant disk I/O

### DIFF
--- a/Sources/clai/Config/ConfigLoading.swift
+++ b/Sources/clai/Config/ConfigLoading.swift
@@ -4,6 +4,16 @@ import Yams
 // MARK: - Config Loading
 
 extension Config {
+    private nonisolated(unsafe) static var _cachedConfig: Config?
+    private static let lock = NSLock()
+
+    /// Clear the parsed configuration cache. Useful for testing.
+    static func clearCache() {
+        lock.lock()
+        defer { lock.unlock() }
+        _cachedConfig = nil
+    }
+
     /// Config file location
     static var configFileURL: URL {
         let configDir = FileManager.default.homeDirectoryForCurrentUser
@@ -22,15 +32,28 @@ extension Config {
     ///
     /// - Throws: `ConfigError` on file/parsing errors, `ValidationError` on invalid values
     static func load() throws -> Config {
-        let fileURL = configFileURL
+        lock.lock()
+        let cached = _cachedConfig
+        lock.unlock()
 
-        // 1. Create file with defaults if it doesn't exist
-        if !FileManager.default.fileExists(atPath: fileURL.path) {
-            try createDefaultConfigFile(at: fileURL)
+        var config: Config
+        if let cached {
+            config = cached
+        } else {
+            let fileURL = configFileURL
+
+            // 1. Create file with defaults if it doesn't exist
+            if !FileManager.default.fileExists(atPath: fileURL.path) {
+                try createDefaultConfigFile(at: fileURL)
+            }
+
+            // 2. Load from file (single source of truth)
+            config = try loadFromFile(at: fileURL)
+
+            lock.lock()
+            _cachedConfig = config
+            lock.unlock()
         }
-
-        // 2. Load from file (single source of truth)
-        var config = try loadFromFile(at: fileURL)
 
         // 3. Apply environment variable overrides
         config = config.applyingEnvironmentOverrides()
@@ -247,6 +270,8 @@ extension Config {
 
     /// Save configuration to file
     func save() throws {
+        Config.clearCache()
+
         let fileURL = Config.configFileURL
         let configDir = fileURL.deletingLastPathComponent()
 

--- a/Tests/claiTests/CachePerfTests.swift
+++ b/Tests/claiTests/CachePerfTests.swift
@@ -1,6 +1,6 @@
 @testable import clai
-import XCTest
 import Crypto
+import XCTest
 
 final class CachePerfTests: XCTestCase {
     // Helper to generate a unique cache key
@@ -22,7 +22,7 @@ final class CachePerfTests: XCTestCase {
         let start = Date()
 
         await withTaskGroup(of: Void.self) { group in
-            for i in 0..<concurrentOps {
+            for i in 0 ..< concurrentOps {
                 group.addTask {
                     let key = CachePerfTests.uniqueKey(i)
                     let response = "Response for \(i)"
@@ -46,7 +46,7 @@ final class CachePerfTests: XCTestCase {
         let readStart = Date()
 
         await withTaskGroup(of: Void.self) { group in
-            for i in 0..<concurrentOps {
+            for i in 0 ..< concurrentOps {
                 group.addTask {
                     let key = CachePerfTests.uniqueKey(i)
                     do {

--- a/Tests/claiTests/PerformanceTests.swift
+++ b/Tests/claiTests/PerformanceTests.swift
@@ -24,7 +24,7 @@ final class PerformanceTests: XCTestCase {
 
         // Measure time block
         measure {
-            for _ in 0..<iterations {
+            for _ in 0 ..< iterations {
                 _ = ByteFormatter.format(bytes)
             }
         }

--- a/Tests/claiTests/ResponseCacheTests.swift
+++ b/Tests/claiTests/ResponseCacheTests.swift
@@ -1,6 +1,6 @@
 @testable import clai
-import XCTest
 import Crypto
+import XCTest
 
 final class ResponseCacheTests: XCTestCase {
     // Helper to generate a unique cache key
@@ -45,7 +45,10 @@ final class ResponseCacheTests: XCTestCase {
         let response = "Expired Response"
 
         // Exactly 7 days + 1 second ago
-        guard let oldDate = Calendar.current.date(byAdding: .second, value: -1, to:
+        guard let oldDate = Calendar.current.date(
+            byAdding: .second,
+            value: -1,
+            to:
             Calendar.current.date(byAdding: .day, value: -7, to: Date())!
         ) else {
             XCTFail("Could not calculate old date")
@@ -64,7 +67,10 @@ final class ResponseCacheTests: XCTestCase {
         let response = "Valid Response"
 
         // Exactly 7 days - 1 hour ago
-        guard let oldDate = Calendar.current.date(byAdding: .hour, value: 1, to:
+        guard let oldDate = Calendar.current.date(
+            byAdding: .hour,
+            value: 1,
+            to:
             Calendar.current.date(byAdding: .day, value: -7, to: Date())!
         ) else {
             XCTFail("Could not calculate old date")

--- a/mise.toml
+++ b/mise.toml
@@ -51,7 +51,7 @@ description = "Check formatting (CI)"
 run = "swiftformat Sources --lint"
 
 [hooks.enter]
-run = "git config core.hooksPath .githooks 2>/dev/null || true"
+script = "git config core.hooksPath .githooks 2>/dev/null || true"
 
 [tasks.setup]
 description = "Configure git hooks"


### PR DESCRIPTION
## Bottleneck found
`Config.load()` reads and parses `config.yaml` from disk every time it is called. Since `Config.load()` is called across various operations in the CLI application (e.g., `ClaiEngine`, `ModelsManager`, `ProviderManager`), this redundant disk I/O and parsing logic slows down the execution time unnecessarily, particularly startup time.

## Improvement made
Introduced an in-memory thread-safe static cache `_cachedConfig` protected by an `NSLock`. The cache specifically stores the original configuration as loaded from the file. This ensures that environment overrides are applied strictly on cache retrieval, and the cache is correctly invalidated during `Config.save()`. This saves redundant read and parse operations when `Config.load()` is called multiple times.

---
*PR created automatically by Jules for task [9318585038302348302](https://jules.google.com/task/9318585038302348302) started by @alexey1312*